### PR TITLE
Update RO_RCS_Config.cfg for 1kN Thruster Fuel Gauge

### DIFF
--- a/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
+++ b/GameData/RealismOverhaul/RO_SuggestedMods/RO_RCS_Config.cfg
@@ -83,6 +83,7 @@
 			{
 				ratio = 1.0
 				name = HTP
+				DrawGauge = True
 			}
 			IspSL = 0.177
 			IspV = 0.465
@@ -98,6 +99,7 @@
 			{
 				ratio = 1.0
 				name = Hydrazine
+				DrawGauge = True
 			}
 			IspSL = 0.274
 			IspV = 0.72
@@ -113,6 +115,7 @@
 			{
 				ratio = 1.0
 				name = NitrousOxide
+				DrawGauge = True
 			}
 			IspSL = 0.2
 			IspV = 0.525
@@ -128,6 +131,7 @@
 			{
 				ratio = 1.0
 				name = Helium
+				DrawGauge = True
 			}
 			IspSL = 0.203
 			IspV = 0.453
@@ -143,6 +147,7 @@
 			{
 				ratio = 1.0
 				name = Nitrogen
+				DrawGauge = True
 			}
 			cost = -10
 			IspSL = 0.1001462
@@ -240,6 +245,7 @@
 			{
 				ratio = 1.0
 				name = CaveaB
+				DrawGauge = True
 			}
 			IspSL = 0.274
 			IspV = 0.939


### PR DESCRIPTION
Modification to allow 1kN thruster or other RCS monopropellant based engines show fuel gauges.  Did not appear to add gauges to RCS.  See Issue #1681  "1kN Thruster has no fuel bars "